### PR TITLE
Fix MoveNet nodes

### DIFF
--- a/src/sancho_perception/sancho_perception/movenet_inference_node.py
+++ b/src/sancho_perception/sancho_perception/movenet_inference_node.py
@@ -304,7 +304,7 @@ class MoveNetInferenceNode(LifecycleNode):
             person.id = pid
             person.keypoints = [Point(x=p[0], y=p[1], z=0.0) for p in kpts]
             person.keypoints3d = [Point(x=0.0, y=0.0, z=0.0) for _ in kpts]
-            person.scores = [Float32(data=float(s)) for s in scores]
+            person.scores = [float(s) for s in scores]
             person.avg_depth = 0.0
             pp_msg.persons.append(person)
         self.detections_pub.publish(pp_msg)

--- a/src/sancho_perception/sancho_perception/movenet_postprocessing_node.py
+++ b/src/sancho_perception/sancho_perception/movenet_postprocessing_node.py
@@ -363,12 +363,20 @@ class MoveNetPostprocessingNode(LifecycleNode):
         pose_array_msg.header = persons_3d_msg.header
 
         for person in persons_3d_msg.persons:
-            x, y, z = person.keypoints3d[0:3]
-            if x == 0.0 and y == 0.0 and z == 0.0:
+            first_kp = person.keypoints3d[0]
+            if (
+                first_kp.x == 0.0
+                and first_kp.y == 0.0
+                and first_kp.z == 0.0
+            ):
                 continue  # skip invalid
 
             pose = Pose()
-            pose.position = Point(x=float(x), y=float(y), z=float(z))
+            pose.position = Point(
+                x=float(first_kp.x),
+                y=float(first_kp.y),
+                z=float(first_kp.z),
+            )
             pose.orientation = Quaternion(x=0.0, y=0.0, z=0.0, w=1.0)
             pose_array_msg.poses.append(pose)
 
@@ -453,7 +461,7 @@ class MoveNetPostprocessingNode(LifecycleNode):
 
         for person in persons_3d_msg.persons:
             keypoints_3d = person.keypoints3d
-            if len(keypoints_3d) != self.expected_kpts * 3:
+            if len(keypoints_3d) != self.expected_kpts:
                 self.get_logger().debug(
                     f"Persona {person.id}: número de keypoints 3D inesperado."
                 )


### PR DESCRIPTION
## Summary
- fix PoseArray generation from 3D detections
- validate keypoints count correctly
- publish scores as primitive floats

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_flake8')*

------
https://chatgpt.com/codex/tasks/task_e_687eaedf0b1083299a6dc0b8e663e05f